### PR TITLE
Notify inactive users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,4 +55,5 @@ group :test do
   gem 'database_cleaner'
   gem 'colored'
   gem 'deadweight', :require => 'deadweight/hijack/rails'
+  gem 'mocha'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,11 +133,14 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.1)
     minitest (5.4.3)
     minitest-color (0.0.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     multi_json (1.10.1)
     multi_test (0.1.1)
     nested_form (0.3.2)
@@ -309,6 +312,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   minitest-color
+  mocha
   nested_form
   newrelic_rpm
   pg

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,16 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user
 
-  before_filter :authenticate_user, :track
+  before_filter :authenticate_user, :track, :record_activity
   before_filter :remote_cant_access, except: [:index, :show]
   before_filter :http_basic_auth, :if => :http_basic_auth_required?
+
+  def record_activity
+    if current_user && current_user.remote?
+      current_user.last_active_at = DateTime.now
+      current_user.save
+    end
+  end
 
   private
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -21,4 +21,8 @@ class UserMailer < ActionMailer::Base
     mail(to: "#{user.email}", subject: "New post in #{message.title}")
   end
 
+  def reminder_to_inactive_users(user)
+    @user = user
+    mail(to: @user.email, subject: t('.subject'))
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,4 +109,5 @@ class User < ActiveRecord::Base
     end
     user
   end
+
 end

--- a/app/views/user_mailer/reminder_to_inactive_users.haml
+++ b/app/views/user_mailer/reminder_to_inactive_users.haml
@@ -1,0 +1,7 @@
+!!!
+%html
+  %head
+    %meta{'content' => 'text/html; charset=UTF-8', 'http-equiv' =>'Content-Type'}
+  %body
+    :markdown
+      #{t('.body', user_name: @user.name)}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -490,6 +490,22 @@ Nous organiserons également des rencontres physiques à l'occasion d'évènemen
     contact:
       contact_base: "contact depuis: %{name} [%{email}] "
       subject: "Contact depuis la plateforme"
+    reminder_to_inactive_users:
+      subject: "Vous nous manquez ! - FOAD de Simplon.co"
+      body: "
+      #Vous n'avez pas visité la FOAD depuis une semaine !
+
+
+      Bonjour %{user_name},
+
+
+      Nous avons noté que vous n'aviez pas eu l'occasion de visiter la FOAD depuis une semaine. Beaucoup de choses se sont passées depuis : n'hésitez pas à lire [la dernière leçon mise en ligne](http://foad.simplon.co/lessons) ou [les derniers messages postés sur le forum](http://foad.simplon.co/messages).
+
+
+      A bientôt !
+
+
+      L'équipe Simplon"
     reset_password:
       subject: "Votre accès à la plateforme Simplonline - FOAD de Simplon.co"
       body: "

--- a/db/migrate/20150303135539_add_last_active_at_to_users.rb
+++ b/db/migrate/20150303135539_add_last_active_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastActiveAtToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :last_active_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141114105930) do
+ActiveRecord::Schema.define(version: 20150303135539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -177,6 +177,7 @@ ActiveRecord::Schema.define(version: 20141114105930) do
     t.string   "password_digest"
     t.string   "reset_password_key"
     t.string   "student_type",       default: "remote"
+    t.datetime "last_active_at"
   end
 
 end

--- a/lib/tasks/inactive_users.rake
+++ b/lib/tasks/inactive_users.rake
@@ -1,0 +1,18 @@
+namespace :simplon do
+
+  # launch via cron everyday
+  # 16 00 * * * cd /path/to/myrailsapp && /path/to/rake RAILS_ENV=production simplon:inactive_users
+
+  desc "Email inactive remote users since one week"
+  task :inactive_users => :environment do
+    p "Collecting inactive users..."
+    one_week = Time.now.weeks_ago(1)
+    two_weeks = Time.now.weeks_ago(2)
+    users = User.where(["last_active_at > ? and last_active_at < ?", one_week, two_weeks])
+    users.each do |user|
+      UserMailer.reminder_to_inactive_users(user)
+      p "Email sent to #{user}"
+    end
+    p "#{users.length} emails sent!"
+  end
+end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,5 @@
+require 'test_helper'
+
+class ApplicationControllerTest < ActionController::TestCase
+
+end

--- a/test/controllers/chapters_controller_test.rb
+++ b/test/controllers/chapters_controller_test.rb
@@ -89,5 +89,13 @@ class ChaptersControllerTest < ActionController::TestCase
     assert_equal lesson, assigns(:lesson)
   end
 
-
+  test "save user last activity timestamp" do
+    user = FactoryGirl.create(:user, student_type: User::REMOTE)
+    session[:user_id] = user.id
+    some_date = DateTime.new(2014, 12, 12, 1, 1, 1)
+    DateTime.stubs(:now).returns(some_date)
+    get :index
+    user.reload
+    assert_equal(some_date, user.last_active_at)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -133,4 +133,13 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [chapter], user.chapters
   end
 
+  test "user last active at" do
+    user = FactoryGirl.build(:user)
+    a_date = DateTime.new(2015, 3, 1, 1, 1, 1)
+    assert_nothing_raised do
+      user.last_active_at = a_date
+    end
+    assert_equal(a_date, user.last_active_at)
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'factory_girl'
+require 'mocha/mini_test'
 include ActionDispatch::TestProcess
 
 FactoryGirl.find_definitions


### PR DESCRIPTION
Send a nice and friendly email to remote users when they didn't visit ny page of the FOAD since one week.
